### PR TITLE
Adopt a Code of Conduct to ensure a healthy atmosphere for contributors

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,106 @@
+## Code of Conduct
+
+### Quick Version
+
+The Pancake community is dedicated to providing a harassment-free
+experience for everyone, regardless of gender, gender identity and
+expression, sexual orientation, disability, physical appearance,
+body size, race, or religion. We do not tolerate harassment of
+participants in any form.
+
+This code of conduct applies to all Pancake sponsored spaces,
+including our blog, mailing lists, and wiki, as well as any other
+spaces that Pancake hosts, both online and off. Anyone who violates
+this code of conduct may be sanctioned or expelled from these spacesat
+the discretion of the Pancake Anti-Abuse Team.
+
+Some Pancake-sponsored spaces may have additional rules in place, which
+will be made clearly available to participants. Participants are
+responsible for knowing and abiding by these rules.
+
+### Definitions
+
+Harassment includes:
+
+- Offensive comments related to gender, gender identity and expression,
+  sexual orientation, disability, mental illness, neuro(a)typicality,
+  physical appearance, body size, race, or religion
+- Unwelcome comments regarding a person’s lifestyle choices and
+  practices, including those related to food, health, parenting, drugs,
+  and employment.
+- Deliberate misgendering or use of ‘dead’ or rejected names
+- Gratuitous or off-topic sexual images or behaviour  in spaces where
+  they’re not appropriate
+- Physical contact and simulated physical contact (eg, textual
+  descriptions like “*hug*” or “*backrub*”) without consent or after a
+  request to stop.
+- Threats of violence
+- Incitement of violence towards any individual, including encouraging
+  a person to commit suicide or to engage in self-harm
+- Deliberate intimidation
+- Stalking or following
+- Harassing photography or recording, including logging online activity
+  for harassment purposes
+- Sustained disruption of discussion
+- Unwelcome sexual attention
+- Pattern of inappropriate social contact, such as requesting/assuming
+  inappropriate levels of intimacy with others
+- Continued one-on-one communication after requests to cease
+- Deliberate “outing” of any aspect of a person’s identity without their
+  consent except as necessary to protect other Pancake members or other
+  vulnerable people from intentional abuse
+- Publication of non-harassing private communication
+
+The Pancake community prioritizes marginalized people’s safety over
+privileged people’s comfort. The Pancake Anti-Abuse Team will not act on
+complaints regarding:
+
+- ‘Reverse’ -isms, including ‘reverse racism,’ ‘reverse sexism,’ and
+  ‘cisphobia’ (because these things don’t exist)
+- Reasonable communication of boundaries, such as “leave me alone,”
+  “go away,” or “I’m not discussing this with you.”
+- Refusal to explain or debate social justice concepts
+- Communicating in a ‘tone’ you don’t find congenial
+- Criticizing racist, sexist, cissexist, or otherwise oppressive
+  behavior or assumptions
+
+### Reporting
+
+If you are being harassed by a member of the Pancake community,
+notice that someone else is being harassed, or have any other concerns,
+please contact the Pancake Anti-Abuse Team. If the person who is
+harassing you is on the team, they will recuse themselves from handling
+your incident. We will respond as promptly as we can.
+
+This code of conduct applies to Pancake sponsored spaces, but if
+you are being harassed by a member of the Pancake community outside our
+spaces, we still want to know about it. We will take all good-faith
+reports of harassment by Pancake community members, especially bloggers,
+seriously. This includes harassment outside our spaces and harassment
+that took place at any point in time. The abuse team reserves the right
+to exclude people from the Pancake community based on their past
+behavior, including behavior outside Pancake spaces and behavior towards
+people who are not in the Pancake community.
+
+In order to protect volunteers from abuse and burnout, we reserve the
+right to reject any report we believe to have been made in bad faith.
+The Pancake Anti-Abuse Team is not here to explain power differentials
+or other basic social justice concepts to you. Reports intended to
+silence legitimate criticism may be deleted without response.
+
+We will respect confidentiality requests for the purpose of protecting
+victims of abuse. At our discretion, we may publicly name a person about
+whom we’ve received harassment complaints, or privately warn third
+parties about them, if we believe that doing so will increase the safety
+of Pancake members or the general public. We will not name harassment
+victims without their affirmative consent.
+
+### Consequences
+
+Participants asked to stop any harassing behavior are expected to comply
+immediately.
+
+If a participant engages in harassing behavior, the Pancake Anti-Abuse
+Team may take any action they deem appropriate, up to and including
+expulsion from all Pancake spaces and identification of the participant
+as a harasser to other Pancake members or the general public.


### PR DESCRIPTION
A CoC is a document that establishes expectations for behavior for your
project's participants. Adopting, and enforcing, a code of conduct can help
create a positive social atmosphere for your community.

Before adopting this CoC, we should form a Pancake Anti-Abuse team, with diversity of its members in mind. However, seeing that this project currently only has two contributors, maybe this should be postponed until an acceptable level of diversity can be achieved. It is nonetheless important that we proactively adopt a CoC to create a welcoming atmosphere for new contributors.